### PR TITLE
Fix: remove failing prank in FloorToken.t.sol

### DIFF
--- a/test/FloorToken.t.sol
+++ b/test/FloorToken.t.sol
@@ -316,7 +316,6 @@ contract TransferTaxFloorTokenTest is Test {
             deadline: block.timestamp
         });
 
-        vm.startPrank(alice);
         token.approve(address(lbRouter), type(uint256).max);
         wNative.approve(address(lbRouter), type(uint256).max);
 


### PR DESCRIPTION
Prank is called twice l280 & l319 causing the test to fail